### PR TITLE
'Cancel' for PromiseKit

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,4 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "CoreCancel"
+
 github "BoltsFramework/Bolts-ObjC" ~> 1.9

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "BoltsFramework/Bolts-ObjC" "1.9.0"
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/PromiseKit" "087b3cf470890ff9ea841212e2f3e285fecf3988"

--- a/Sources/BFTask+Promise.swift
+++ b/Sources/BFTask+Promise.swift
@@ -34,8 +34,6 @@ extension BFCancellationTokenSource: CancellableTask {
     }
 }
 
-//////////////////////////////////////////////////////////// Cancellable wrapper
-
 extension CancellablePromise {
     /**
      The provided closure is executed when this cancellable promise is resolved.

--- a/Tests/TestBolts.swift
+++ b/Tests/TestBolts.swift
@@ -21,3 +21,31 @@ class TestBolts: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 }
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension TestBolts {
+    func testCancel() {
+        let ex = expectation(description: "")
+
+        let value = { NSString(string: "1") }
+        var task: BFTask<NSString>?
+        
+        let p = firstly { () -> CancellablePromise<Void> in
+            return CancellablePromise()
+        }
+        p.then { _ -> BFTask<NSString> in
+            task = BFTask(result: value())
+            p.cancel()
+            return task!
+        }.done { obj in
+            XCTAssertEqual(obj, value())
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+}
+


### PR DESCRIPTION
These are the diffs for option 1 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 1 the new cancellation code is included with CorePromise.

There repositories involved with the pull request for option 1 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
