### PR TITLE
'Cancel' for PromiseKit option 2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,4 @@
 github "mxcl/PromiseKit" ~> 6.0
 github "BoltsFramework/Bolts-ObjC" ~> 1.9
+#github "PromiseKit/Cancel" ~> 1.0
+github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "PMKCancel"
 github "BoltsFramework/Bolts-ObjC" ~> 1.9
-
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,5 @@
 github "mxcl/PromiseKit" ~> 6.0
 github "BoltsFramework/Bolts-ObjC" ~> 1.9
+
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "BoltsFramework/Bolts-ObjC" "1.9.0"
 github "dougzilla32/Cancel" "1.0.0"
-github "mxcl/PromiseKit" "6.3.4"
+github "dougzilla32/PromiseKit" "a0217bd7b69af68237dcdeee0197e63259b9d445"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
 github "BoltsFramework/Bolts-ObjC" "1.9.0"
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/Cancel" "1.0.0"
+github "mxcl/PromiseKit" "6.3.4"

--- a/PMKBolts.xcodeproj/project.pbxproj
+++ b/PMKBolts.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 			inputPaths = (
 				PromiseKit,
 				Bolts,
+				PMKCancel,
 			);
 			name = "Embed Carthage Frameworks";
 			outputPaths = (

--- a/Sources/BFTask+Promise.swift
+++ b/Sources/BFTask+Promise.swift
@@ -1,4 +1,5 @@
 #if !PMKCocoaPods
+import PMKCancel
 import PromiseKit
 #endif
 import Bolts
@@ -21,6 +22,38 @@ extension Promise {
                     }
                     return nil
                 })
+            }
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension BFCancellationTokenSource: CancellableTask {
+    public var isCancelled: Bool {
+        return token.isCancellationRequested
+    }
+}
+
+extension CancellablePromise {
+    /**
+     The provided closure is executed when this promise is resolved.
+     */
+    public func thenCC<U>(on q: DispatchQueue? = conf.Q.map, body: @escaping (T) -> BFTask<U>) -> CancellablePromise<U?> {
+        return then(on: q) { tee -> CancellablePromise<U?> in
+            let tokenSource = BFCancellationTokenSource()
+            let task = body(tee)
+            return CancellablePromise<U?>(task: tokenSource) { seal in
+                task.continueWith(block: { task in
+                    if task.isCompleted {
+                        seal.fulfill(task.result)
+                    } else if let error = task.error {
+                        seal.reject(error)
+                    } else {
+                        seal.reject(PMKError.invalidCallingConvention)
+                    }
+                    return nil
+                }, cancellationToken: tokenSource.token)
             }
         }
     }

--- a/Tests/TestBolts.swift
+++ b/Tests/TestBolts.swift
@@ -1,3 +1,4 @@
+import PMKCancel
 import PromiseKit
 import PMKBolts
 import XCTest
@@ -21,3 +22,31 @@ class TestBolts: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 }
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension TestBolts {
+    func testCancel() {
+        let ex = expectation(description: "")
+
+        let value = { NSString(string: "1") }
+        var task: BFTask<NSString>?
+        
+        let p = firstly { () -> CancellablePromise<Void> in
+            return CancellablePromise()
+        }
+        p.thenCC { _ -> BFTask<NSString> in
+            task = BFTask(result: value())
+            p.cancel()
+            return task!
+        }.done { obj in
+            XCTAssertEqual(obj, value())
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+}
+


### PR DESCRIPTION
These are the diffs for option 2 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 2 the new cancellation code goes in a new PromiseKit extension called PMKCancel.

The repository for the new PMKCancel extension is currently hosted at https://github.com/dougzilla32/Cancel, but would be moved to https://github.com/PromiseKit/Cancel if option 2 is accepted.

There repositories with pull requests for option 2 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[dougzilla32/Cancel](https://github.com/dougzilla32/Cancel) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
